### PR TITLE
Cache PyPI responses for one hour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 node_modules
+requests-cache.sqlite
 results.json
 top-pypi-packages.json
 wheel.svg

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pre-commit==3.8.0
 pytz==2024.1
 requests==2.32.3
+requests-cache==1.2.1

--- a/utils.py
+++ b/utils.py
@@ -1,8 +1,7 @@
 import datetime
 import json
 import pytz
-import requests
-
+import requests_cache
 
 BASE_URL = "https://pypi.org/pypi"
 
@@ -18,7 +17,8 @@ DEPRECATED_PACKAGES = {
     "sklearn",
 }
 
-SESSION = requests.Session()
+# Keep responses for one hour
+SESSION = requests_cache.CachedSession("requests-cache", expire_after=60 * 60)
 
 
 def get_json_url(package_name):


### PR DESCRIPTION
Keep the PyPI requests for an hour. Makes local development quicker, `make generate` goes from 6.5 seconds to under 1 second.

Delete `requests-cache.sqlite` to get fresh results.

On `main`:
```
make generate  1.52s user 0.20s system 26% cpu 6.595 total
```
PR, first run:
```
make generate  1.58s user 0.62s system 34% cpu 6.407 total
```
PR, with cache:
```
make generate  0.77s user 0.12s system 91% cpu 0.973 total
```