### PR TITLE
Report top 360 packages with binary extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ requests-cache.sqlite
 results.json
 top-pypi-packages.json
 wheel.svg
+.venv

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
 help:
 	@echo "make help     -- print this help"
+	@echo "make fetch    -- fetch the top PyPI packages data file"
 	@echo "make generate -- regenerate the json"
 
-generate:
+fetch:
 	wget https://hugovk.github.io/top-pypi-packages/top-pypi-packages.min.json -O top-pypi-packages.json
+
+generate: fetch
 	python3 generate.py

--- a/generate.py
+++ b/generate.py
@@ -1,8 +1,7 @@
 from svg_wheel import generate_svg_wheel
 from utils import (
-    annotate_wheels,
+    get_annotated_packages,
     get_top_packages,
-    remove_irrelevant_packages,
     save_to_file,
 )
 
@@ -10,10 +9,9 @@ TO_CHART = 360
 
 
 def main(to_chart: int = TO_CHART) -> None:
-    packages = remove_irrelevant_packages(get_top_packages(), to_chart)
-    annotate_wheels(packages)
+    packages = get_annotated_packages(get_top_packages(), to_chart)
     save_to_file(packages, "results.json")
-    generate_svg_wheel(packages, to_chart)
+    generate_svg_wheel(packages)
 
 
 if __name__ == "__main__":

--- a/index.html
+++ b/index.html
@@ -63,16 +63,16 @@
                 <p><a href="https://pypi.org/project/wheel">Wheels</a> are <a href="https://packaging.python.org/en/latest/specifications/binary-distribution-format/">the standard binary format</a> for distributing Python packages. See <a href="https://pythonwheels.com/">pythonwheels.com</a>.</p>
                 <h2 id="what">What are free-threaded wheels?</h2>
                 <p>Work is underway to make the Global Interpreter Lock (GIL) optional (see <a href="https://peps.python.org/pep-0703/">PEP 703</a>).
-                    Pure-Python wheels are already free-threaded, but wheels with extensions need to be updated for free-threaded Python.
+                    Pure-Python wheels can already be used in free-threaded builds, but wheels with extensions need to be updated for free-threaded Python.
                     This site shows which packages have been updated for free-threading.
                     See <a href="https://labs.quansight.org/blog/free-threaded-python-rollout">Free-threaded CPython is ready to experiment with!</a>
                 </p>
                 <h2 id="about-list">What is this list?</h2>
-                <p>This site shows the top 360 most-downloaded packages on <a href="https://pypi.org/">PyPI</a> showing which have been uploaded as wheel archives.</p>
+                <p>This site shows the top 360 most-downloaded packages on <a href="https://pypi.org/">PyPI</a> that do not publish a pure Python wheel archive.</p>
                 <ul>
                     <li><span class="text-success">Green</span> packages <span id="success-percent"></span> with a 🧵 offer free-threaded wheels</li>
-                    <li><span class="text-default">Uncoloured</span> packages <span id="default-percent"></span> with a 🐍 offer pure-Python wheels</li>
-                    <li><span class="text-warning">Orange</span> packages <span id="todo-percent"></span> have no wheels ready for free-threading (yet!)</li>
+                    <li><span class="text-default">Uncoloured</span> packages <span id="default-percent"></span> with a 🐍 do not offer any wheels</li>
+                    <li><span class="text-warning">Orange</span> packages <span id="todo-percent"></span> offer wheels, but no wheels ready for free-threading (yet!)</li>
                 </ul>
                 <p>Free-threaded wheels have an <a href="https://packaging.python.org/en/latest/specifications/binary-distribution-format/#file-name-convention">ABI tag</a> ending in <code>t</code>, for example, <code>cp313t</code></code></pre>.</p>
                 <p>Packages that are known to be deprecated are not included (for example, distribute). If your package is incorrectly listed, please <a href="https://github.com/hugovk/free-threaded-wheels/issues/">create a ticket</a>.</p>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pre-commit==4.1.0
 requests==2.32.3
-requests-cache==1.2.1
+# See https://github.com/requests-cache/requests-cache/issues/1008
+requests-cache==0.9.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 pre-commit==4.1.0
-pytz==2025.1
 requests==2.32.3
 requests-cache==1.2.1

--- a/svg_wheel.py
+++ b/svg_wheel.py
@@ -44,10 +44,10 @@ def annular_sector_path(start, stop):
     return PATH_TEMPLATE.format(**points)
 
 
-def add_annular_sectors(wheel, packages, total):
+def add_annular_sectors(svg_wheel, packages, total):
     for index, result in enumerate(packages):
         sector = et.SubElement(
-            wheel,
+            svg_wheel,
             "path",
             d=annular_sector_path(*angles(index, total)),
             attrib={"class": result["css_class"]},
@@ -70,7 +70,7 @@ def angles(index, total):
     return start, stop
 
 
-def add_fraction(wheel, packages, total):
+def add_central_fraction_text(svg_wheel, packages, total):
     text_attributes = {
         "class": "wheel-text",
         "text-anchor": "middle",
@@ -79,25 +79,25 @@ def add_fraction(wheel, packages, total):
         "font-family": '"Helvetica Neue",Helvetica,Arial,sans-serif',
     }
 
-    # Packages with some sort of wheel
-    wheel_packages = sum(package["wheel"] for package in packages)
+    # Packages with a free-threaded wheel
+    free_threaded_packages = sum(package["free_threaded_wheel"] for package in packages)
 
-    packages_with_wheels = et.SubElement(
-        wheel,
+    numerator = et.SubElement(
+        svg_wheel,
         "text",
         x=str(CENTER),
         y=str(CENTER - OFFSET),
         attrib=text_attributes,
     )
-    packages_with_wheels.text = f"{wheel_packages}"
+    numerator.text = f"{free_threaded_packages}"
 
-    title = et.SubElement(packages_with_wheels, "title")
-    percentage = f"{wheel_packages / float(total):.0%}"
-    title.text = percentage
+    numerator_title = et.SubElement(numerator, "title")
+    percentage = f"{free_threaded_packages / float(total):.0%}"
+    numerator_title.text = percentage
 
     # Dividing line
     et.SubElement(
-        wheel,
+        svg_wheel,
         "line",
         x1=str(CENTER - FRACTION_LINE // 2),
         y1=str(CENTER),
@@ -107,30 +107,31 @@ def add_fraction(wheel, packages, total):
     )
 
     # Total packages
-    total_packages = et.SubElement(
-        wheel,
+    denominator = et.SubElement(
+        svg_wheel,
         "text",
         x=str(CENTER),
         y=str(CENTER + OFFSET),
         attrib=text_attributes,
     )
-    total_packages.text = f"{total}"
+    denominator.text = f"{total}"
 
-    title = et.SubElement(total_packages, "title")
-    title.text = percentage
+    denominator_title = et.SubElement(denominator, "title")
+    denominator_title.text = percentage
 
 
-def generate_svg_wheel(packages, total):
-    wheel = et.Element(
+def generate_svg_wheel(packages):
+    total = len(packages)
+    svg_wheel = et.Element(
         "svg",
         viewBox=f"0 0 {2 * CENTER} {2 * CENTER}",
         version="1.1",
         xmlns="http://www.w3.org/2000/svg",
     )
-    add_annular_sectors(wheel, packages, total)
+    add_annular_sectors(svg_wheel, packages, total)
 
-    add_fraction(wheel, packages, total)
+    add_central_fraction_text(svg_wheel, packages, total)
 
     with open("wheel.svg", "wb") as svg:
         svg.write(HEADERS)
-        svg.write(et.tostring(wheel))
+        svg.write(et.tostring(svg_wheel))

--- a/utils.py
+++ b/utils.py
@@ -65,7 +65,9 @@ def annotate_package(package):
     else:
         package["css_class"] = "warning"
         package["icon"] = "\u2717"  # Ballot X
-        package["title"] = "This package publishes binary wheels, but no free-threaded wheels."
+        package["title"] = (
+            "This package publishes binary wheels, but no free-threaded wheels."
+        )
 
 
 def get_top_packages():
@@ -80,6 +82,7 @@ def get_top_packages():
         package["name"] = package.pop("project")
 
     return packages
+
 
 def get_annotated_packages(packages, limit):
     annotated_packages = []

--- a/utils.py
+++ b/utils.py
@@ -107,7 +107,7 @@ def get_annotated_packages(packages, limit):
 
 
 def save_to_file(packages, file_name):
-    now = datetime.datetime.now(tz=datetime.UTC)
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
     with open(file_name, "w") as f:
         f.write(
             json.dumps(


### PR DESCRIPTION
* Projects that publish pure Python wheels are excluded entirely
* Blank sectors now indicate projects that don't publish *any* wheels
* chart description has been updated accordingly

Additional cleanups:

* pytz dependency isn't needed any more
* SVG generator can infer number of packages from the package list
* rename some annotation keys to reflect their current purpose
* rename variables to better distinguish display elements from data

Closes #15