### PR TITLE
Use a different color for packages with a pure-python wheel

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,10 +16,7 @@
         footer{text-align: center;}
         .btn-pure-py {
           background-color: #90EE90;
-          border-bottom-color: #90EE90;
-          border-left-color: #90EE90;
-          border-right-color: #90EE90;
-          border-top-color: #90EE90;
+          border-color: #90EE90;
           color: #000000;
         }
         .text-pure-py {
@@ -27,10 +24,7 @@
         }
         .btn-pure-py:hover {
           background-color: #90EE90;
-          border-bottom-color: #90EE90;
-          border-left-color: #90EE90;
-          border-right-color: #90EE90;
-          border-top-color: #90EE90;
+          border-color: #90EE90;
           color: #000000;
         }
         @media (prefers-color-scheme: dark) {
@@ -72,8 +66,8 @@
                 <h2 id="about-list">What is this list?</h2>
                 <p>This site shows the top 360 most-downloaded packages with extensions on <a href="https://pypi.org/">PyPI</a>:</p>
                 <ul>
-                    <li><span class="text-success">Dark Green</span> packages <span id="success-percent"></span> with a 🧵 offer free-threaded wheels</li>
-                    <li><span class="text-pure-py">Light Green</span> packages <span id="pure-py-percent"></span> offer generic pure Python wheels, but no compiled wheels ready for free-threading (yet!)</li>
+                    <li><span class="text-success">Dark green</span> packages <span id="success-percent"></span> with a 🧵 offer free-threaded wheels</li>
+                    <li><span class="text-pure-py">Light green</span> packages <span id="pure-py-percent"></span> offer generic pure Python wheels, but no compiled wheels ready for free-threading (yet!)</li>
                     <li><span class="text-warning">Orange</span> packages <span id="todo-percent"></span> offer wheels, but no wheels ready for free-threading (yet!)</li>
                 </ul>
                 <p>Free-threaded wheels have an <a href="https://packaging.python.org/en/latest/specifications/binary-distribution-format/#file-name-convention">ABI tag</a> ending in <code>t</code>, for example, <code>cp313t</code></code></pre>.</p>

--- a/index.html
+++ b/index.html
@@ -55,6 +55,7 @@
                 <ul>
                     <li><span class="text-success">Green</span> packages <span id="success-percent"></span> with a 🧵 offer free-threaded wheels</li>
                     <li><span class="text-warning">Orange</span> packages <span id="todo-percent"></span> offer wheels, but no wheels ready for free-threading (yet!)</li>
+                    <li><span class="text-info">Blue</span> packages <span id="pure-py-percent"></span> offer generic pure Python wheels, but no compiled wheels ready for free-threading (yet!)</li>
                 </ul>
                 <p>Free-threaded wheels have an <a href="https://packaging.python.org/en/latest/specifications/binary-distribution-format/#file-name-convention">ABI tag</a> ending in <code>t</code>, for example, <code>cp313t</code></code></pre>.</p>
                 <p>Packages that are known to be deprecated are not included (for example, distribute). If your package is incorrectly listed, please <a href="https://github.com/hugovk/free-threaded-wheels/issues/">create a ticket</a>.</p>
@@ -100,9 +101,11 @@
 
             const successPercentage = (getPackageCount('success') / totalPackages) * 100;
             const todoPercentage = (getPackageCount('warning') / totalPackages) * 100;
+            const purePyPercentage = (getPackageCount('info') / totalPackages) * 100;
 
             document.getElementById('success-percent').innerText = `(${successPercentage.toFixed(0)}%)`;
             document.getElementById('todo-percent').innerText = `(${todoPercentage.toFixed(0)}%)`;
+            document.getElementById('pure-py-percent').innerText = `(${purePyPercentage.toFixed(0)}%)`;
             });
         });
     </script>

--- a/index.html
+++ b/index.html
@@ -22,6 +22,9 @@
           border-top-color: #90EE90;
           color: #000000;
         }
+        .text-pure-py {
+          color: #90EE90;
+        }
         .btn-pure-py:hover {
           background-color: #90EE90;
           border-bottom-color: #90EE90;
@@ -69,9 +72,9 @@
                 <h2 id="about-list">What is this list?</h2>
                 <p>This site shows the top 360 most-downloaded packages with extensions on <a href="https://pypi.org/">PyPI</a>:</p>
                 <ul>
-                    <li><span class="text-success">Green</span> packages <span id="success-percent"></span> with a 🧵 offer free-threaded wheels</li>
+                    <li><span class="text-success">Dark Green</span> packages <span id="success-percent"></span> with a 🧵 offer free-threaded wheels</li>
+                    <li><span class="text-pure-py">Light Green</span> packages <span id="pure-py-percent"></span> offer generic pure Python wheels, but no compiled wheels ready for free-threading (yet!)</li>
                     <li><span class="text-warning">Orange</span> packages <span id="todo-percent"></span> offer wheels, but no wheels ready for free-threading (yet!)</li>
-                    <li><span class="text-info">Blue</span> packages <span id="pure-py-percent"></span> offer generic pure Python wheels, but no compiled wheels ready for free-threading (yet!)</li>
                 </ul>
                 <p>Free-threaded wheels have an <a href="https://packaging.python.org/en/latest/specifications/binary-distribution-format/#file-name-convention">ABI tag</a> ending in <code>t</code>, for example, <code>cp313t</code></code></pre>.</p>
                 <p>Packages that are known to be deprecated are not included (for example, distribute). If your package is incorrectly listed, please <a href="https://github.com/hugovk/free-threaded-wheels/issues/">create a ticket</a>.</p>

--- a/index.html
+++ b/index.html
@@ -14,6 +14,22 @@
         a.btn:last-child{border-bottom-width: 1px; border-bottom-left-radius: 5px; border-bottom-right-radius: 5px;}
         pre {text-align: left;}
         footer{text-align: center;}
+        .btn-pure-py {
+          background-color: #90EE90;
+          border-bottom-color: #90EE90;
+          border-left-color: #90EE90;
+          border-right-color: #90EE90;
+          border-top-color: #90EE90;
+          color: #000000;
+        }
+        .btn-pure-py:hover {
+          background-color: #90EE90;
+          border-bottom-color: #90EE90;
+          border-left-color: #90EE90;
+          border-right-color: #90EE90;
+          border-top-color: #90EE90;
+          color: #000000;
+        }
         @media (prefers-color-scheme: dark) {
           body {
             color: #ccc;
@@ -101,7 +117,7 @@
 
             const successPercentage = (getPackageCount('success') / totalPackages) * 100;
             const todoPercentage = (getPackageCount('warning') / totalPackages) * 100;
-            const purePyPercentage = (getPackageCount('info') / totalPackages) * 100;
+            const purePyPercentage = (getPackageCount('pure-py') / totalPackages) * 100;
 
             document.getElementById('success-percent').innerText = `(${successPercentage.toFixed(0)}%)`;
             document.getElementById('todo-percent').innerText = `(${todoPercentage.toFixed(0)}%)`;

--- a/utils.py
+++ b/utils.py
@@ -37,6 +37,7 @@ def annotate_wheels(packages, to_chart: int) -> list[dict]:
 
         has_other_binary_wheel = False
         has_free_threaded_wheel = False
+        has_pure_python_wheel = False
         url = get_json_url(package["name"])
         response = SESSION.get(url)
         if response.status_code != 200:
@@ -56,13 +57,19 @@ def annotate_wheels(packages, to_chart: int) -> list[dict]:
                     has_free_threaded_wheel = True
                 elif abi_tag != "none":
                     has_other_binary_wheel = True
+                else:
+                    has_pure_python_wheel = True
 
         if has_free_threaded_wheel:
             package["css_class"] = "success"
             package["icon"] = "🧵"
         elif has_other_binary_wheel:
-            package["css_class"] = "warning"
-            package["icon"] = "\u2717"  # Ballot X
+            if not has_pure_python_wheel:
+                package["css_class"] = "warning"
+                package["icon"] = "\u2717"  # Ballot X
+            else:
+                package["css_class"] = "info"
+                package["icon"] = "🐍"
         else:
             # Don't show packages with only sdists or pure Python wheels
             continue

--- a/utils.py
+++ b/utils.py
@@ -68,7 +68,7 @@ def annotate_wheels(packages, to_chart: int) -> list[dict]:
                 package["css_class"] = "warning"
                 package["icon"] = "\u2717"  # Ballot X
             else:
-                package["css_class"] = "info"
+                package["css_class"] = "pure-py"
                 package["icon"] = "🐍"
         else:
             # Don't show packages with only sdists or pure Python wheels

--- a/wheel.css
+++ b/wheel.css
@@ -10,10 +10,10 @@
   fill: #ffc107;
 }
 
-.info {
-  stroke: #0dcaf0;
+.pure-py {
+  stroke: #90EE90;
   stroke-width: 1;
-  fill: #0dcaf0;
+  fill: #90EE90;
 }
 
 line.wheel-line {

--- a/wheel.css
+++ b/wheel.css
@@ -10,6 +10,12 @@
   fill: #ffc107;
 }
 
+.info {
+  stroke: #0dcaf0;
+  stroke-width: 1;
+  fill: #0dcaf0;
+}
+
 line.wheel-line {
   stroke: #333;
 }


### PR DESCRIPTION
This makes the tracker look like this: 

<img width="1153" alt="image" src="https://github.com/user-attachments/assets/f428fb6f-ab6d-4e50-8f1c-8563c7d4cd6d" />